### PR TITLE
allow snapshot to download dependencies

### DIFF
--- a/perf/pom.xml
+++ b/perf/pom.xml
@@ -21,7 +21,7 @@
             <name>shawkins</name>
             <url>https://raw.githubusercontent.com/shawkins/repo/master</url>
             <snapshots>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
             </snapshots>
             <releases>
                 <enabled>true</enabled>


### PR DESCRIPTION
Need to allow `snapshots` for `benchmark-framework` version: 0.0.2-SNAPSHOT :)